### PR TITLE
refactor: introduce domain-specific ID types and rename BibClassification to Classification for improved type safety.

### DIFF
--- a/cmd/biblog/app.go
+++ b/cmd/biblog/app.go
@@ -25,7 +25,7 @@ func NewApp() (*App, error) {
 
 	// Initialize Repositories
 	bibRepo := infrastructure.NewCSVBibliographyRepository(dataDir + "/bibliographies.csv")
-	classRepo := infrastructure.NewCSVBibClassificationRepository(dataDir + "/classifications.csv")
+	classRepo := infrastructure.NewCSVClassificationRepository(dataDir + "/classifications.csv")
 	reviewRepo := infrastructure.NewCSVReviewRepository(dataDir + "/reviews.csv")
 
 	// Initialize Service

--- a/cmd/biblog/main.go
+++ b/cmd/biblog/main.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"bibliography_log/internal/domain"
 	"flag"
 	"fmt"
 	"os"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -121,7 +120,7 @@ func main() {
 		}
 
 		// Parse UUID
-		reviewID, err := uuid.Parse(*updateReviewID)
+		reviewID, err := domain.ParseReviewID(*updateReviewID)
 		if err != nil {
 			fmt.Printf("Invalid review ID format: %v\n", err)
 			os.Exit(1)

--- a/docs/domain_model.md
+++ b/docs/domain_model.md
@@ -3,8 +3,22 @@
 ## Ubiquitous Language
 
 - **Bibliography**: A published work of literature, papers or podcasts that can be read and reviewed.
-- **BibClassification**: A classification of a bibliography.
+- **Classification**: A classification of a bibliography.
 - **Review**: A user's evaluation of a book, consisting of goals and a summary.
+
+## Domain-Specific Types
+
+To improve type safety and prevent accidental misuse of IDs across different entities, the system uses domain-specific ID types instead of raw UUIDs:
+
+- **BibliographyID**: Type-safe wrapper for Bibliography entity IDs
+- **ReviewID**: Type-safe wrapper for Review entity IDs  
+- **ClassificationID**: Type-safe wrapper for Classification entity IDs
+
+These types provide compile-time safety, preventing errors like passing a ReviewID where a BibliographyID is expected. Each type includes helper methods:
+- `String()` - returns UUID string representation
+- `UUID()` - returns underlying uuid.UUID
+- `NewXXXID()` - generates new random ID
+- `ParseXXXID(string)` - parses from string
 
 ## Entities
 
@@ -22,16 +36,16 @@
 
 > **Note:** `AuthorEn` and `TitleEn` are not attributes of the persisted `Bibliography` entity. They are input parameters used temporarily during BibIndex generation in the service layer and are not stored.
 
-### BibClassification
-- **Identity**: `BibClassificationID` (UUID)
+### Classification
+- **Identity**: `ClassificationID` (domain-specific type wrapping UUID)
 - **Attributes**:
   - `CodeNum` (Integer) (e.g., 56)
   - `Name` (String) (e.g., "Technology")
 
 ### Review
-- **Identity**: `ReviewID` (UUID)
+- **Identity**: `ReviewID` (domain-specific type wrapping UUID)
 - **Attributes**:
-  - `BookID` (UUID, Foreign Key)
+  - `BookID` (BibliographyID, Foreign Key)
   - `Goals` (String) - Text field that preserves whitespace and line breaks
   - `Summary` (String) - Text field that preserves whitespace and line breaks
   - `CreatedAt` (DateTime)

--- a/internal/domain/bibliography.go
+++ b/internal/domain/bibliography.go
@@ -1,14 +1,42 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+// BibliographyID is a domain-specific type for Bibliography entity IDs.
+type BibliographyID uuid.UUID
+
+// String returns the string representation of the BibliographyID.
+func (id BibliographyID) String() string {
+	return uuid.UUID(id).String()
+}
+
+// UUID returns the underlying uuid.UUID value.
+func (id BibliographyID) UUID() uuid.UUID {
+	return uuid.UUID(id)
+}
+
+// NewBibliographyID generates a new random BibliographyID.
+func NewBibliographyID() BibliographyID {
+	return BibliographyID(uuid.New())
+}
+
+// ParseBibliographyID parses a string into a BibliographyID.
+func ParseBibliographyID(s string) (BibliographyID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return BibliographyID{}, fmt.Errorf("invalid bibliography ID: %w", err)
+	}
+	return BibliographyID(id), nil
+}
+
 // Bibliography represents a published work.
 type Bibliography struct {
-	ID            uuid.UUID
+	ID            BibliographyID
 	BibIndex      string // e.g., "B56SK24DMD"
 	Code          string // e.g., "B56"
 	Type          string // e.g., "Book", "Essay"

--- a/internal/domain/classification.go
+++ b/internal/domain/classification.go
@@ -1,10 +1,41 @@
 package domain
 
-import "github.com/google/uuid"
+import (
+	"fmt"
 
-// BibClassification represents a classification category.
-type BibClassification struct {
-	ID      uuid.UUID
+	"github.com/google/uuid"
+)
+
+// ClassificationID is a domain-specific type for Classification entity IDs.
+type ClassificationID uuid.UUID
+
+// String returns the string representation of the ClassificationID.
+func (id ClassificationID) String() string {
+	return uuid.UUID(id).String()
+}
+
+// UUID returns the underlying uuid.UUID value.
+func (id ClassificationID) UUID() uuid.UUID {
+	return uuid.UUID(id)
+}
+
+// NewClassificationID generates a new random ClassificationID.
+func NewClassificationID() ClassificationID {
+	return ClassificationID(uuid.New())
+}
+
+// ParseClassificationID parses a string into a ClassificationID.
+func ParseClassificationID(s string) (ClassificationID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return ClassificationID{}, fmt.Errorf("invalid classification ID: %w", err)
+	}
+	return ClassificationID(id), nil
+}
+
+// Classification represents a classification category.
+type Classification struct {
+	ID      ClassificationID
 	CodeNum int    // e.g., 56
 	Name    string // e.g., "Technology"
 }

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -1,26 +1,24 @@
 package domain
 
-import "github.com/google/uuid"
-
 // BibliographyRepository defines the interface for persistence.
 type BibliographyRepository interface {
 	Save(bibliography *Bibliography) error
 	FindAll() ([]*Bibliography, error)
-	FindByID(id uuid.UUID) (*Bibliography, error)
+	FindByID(id BibliographyID) (*Bibliography, error)
 	FindByBibIndex(bibIndex string) (*Bibliography, error)
 }
 
-// BibClassificationRepository defines the interface for persistence.
-type BibClassificationRepository interface {
-	Save(classification *BibClassification) error
-	FindAll() ([]*BibClassification, error)
-	FindByCodeNum(codeNum int) (*BibClassification, error)
+// ClassificationRepository defines the interface for persistence.
+type ClassificationRepository interface {
+	Save(classification *Classification) error
+	FindAll() ([]*Classification, error)
+	FindByCodeNum(codeNum int) (*Classification, error)
 }
 
 // ReviewRepository defines the interface for persistence.
 type ReviewRepository interface {
 	Save(review *Review) error
 	FindAll() ([]*Review, error)
-	FindByID(id uuid.UUID) (*Review, error)
-	FindByBookID(bookID uuid.UUID) ([]*Review, error)
+	FindByID(id ReviewID) (*Review, error)
+	FindByBookID(bookID BibliographyID) ([]*Review, error)
 }

--- a/internal/domain/review.go
+++ b/internal/domain/review.go
@@ -1,15 +1,43 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+// ReviewID is a domain-specific type for Review entity IDs.
+type ReviewID uuid.UUID
+
+// String returns the string representation of the ReviewID.
+func (id ReviewID) String() string {
+	return uuid.UUID(id).String()
+}
+
+// UUID returns the underlying uuid.UUID value.
+func (id ReviewID) UUID() uuid.UUID {
+	return uuid.UUID(id)
+}
+
+// NewReviewID generates a new random ReviewID.
+func NewReviewID() ReviewID {
+	return ReviewID(uuid.New())
+}
+
+// ParseReviewID parses a string into a ReviewID.
+func ParseReviewID(s string) (ReviewID, error) {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return ReviewID{}, fmt.Errorf("invalid review ID: %w", err)
+	}
+	return ReviewID(id), nil
+}
+
 // Review represents a user's evaluation of a bibliography.
 type Review struct {
-	ID        uuid.UUID
-	BookID    uuid.UUID
+	ID        ReviewID
+	BookID    BibliographyID
 	Goals     string
 	Summary   string
 	CreatedAt time.Time

--- a/internal/infrastructure/bibliography_repository_test.go
+++ b/internal/infrastructure/bibliography_repository_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 func TestCSVBibliographyRepository_SaveAndFind(t *testing.T) {
@@ -28,7 +26,7 @@ func TestCSVBibliographyRepository_SaveAndFind(t *testing.T) {
 
 	// Test Save
 	bib := &domain.Bibliography{
-		ID:            uuid.New(),
+		ID:            domain.NewBibliographyID(),
 		BibIndex:      "B56TEST",
 		Code:          "B56",
 		Type:          "Book",

--- a/internal/service/bibliography_service.go
+++ b/internal/service/bibliography_service.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type BibliographyService struct {
 	bibRepo   domain.BibliographyRepository
-	classRepo domain.BibClassificationRepository
+	classRepo domain.ClassificationRepository
 }
 
-func NewBibliographyService(bibRepo domain.BibliographyRepository, classRepo domain.BibClassificationRepository) *BibliographyService {
+func NewBibliographyService(bibRepo domain.BibliographyRepository, classRepo domain.ClassificationRepository) *BibliographyService {
 	return &BibliographyService{
 		bibRepo:   bibRepo,
 		classRepo: classRepo,
@@ -92,7 +90,7 @@ func (s *BibliographyService) AddBibliography(title, author, isbn, description, 
 
 	// 3. Create Entity
 	bib := &domain.Bibliography{
-		ID:            uuid.New(),
+		ID:            domain.NewBibliographyID(),
 		BibIndex:      bibIndex,
 		Code:          code,
 		Type:          typeStr,
@@ -119,7 +117,7 @@ func (s *BibliographyService) FindByBibIndex(bibIndex string) (*domain.Bibliogra
 	return s.bibRepo.FindByBibIndex(bibIndex)
 }
 
-func (s *BibliographyService) AddClassification(codeNum int, name string) (*domain.BibClassification, error) {
+func (s *BibliographyService) AddClassification(codeNum int, name string) (*domain.Classification, error) {
 	// Validate name is not empty or whitespace
 	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("classification name must not be empty")
@@ -138,8 +136,8 @@ func (s *BibliographyService) AddClassification(codeNum int, name string) (*doma
 		return nil, fmt.Errorf("classification with code %d already exists", codeNum)
 	}
 
-	class := &domain.BibClassification{
-		ID:      uuid.New(),
+	class := &domain.Classification{
+		ID:      domain.NewClassificationID(),
 		CodeNum: codeNum,
 		Name:    name,
 	}

--- a/internal/service/bibliography_service_test.go
+++ b/internal/service/bibliography_service_test.go
@@ -4,20 +4,18 @@ import (
 	"bibliography_log/internal/domain"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // MockBibliographyRepository is a mock implementation of domain.BibliographyRepository
 type MockBibliographyRepository struct {
 	SavedBibliography *domain.Bibliography
-	Bibliographies    map[uuid.UUID]*domain.Bibliography
+	Bibliographies    map[domain.BibliographyID]*domain.Bibliography
 }
 
 func (m *MockBibliographyRepository) Save(b *domain.Bibliography) error {
 	m.SavedBibliography = b
 	if m.Bibliographies == nil {
-		m.Bibliographies = make(map[uuid.UUID]*domain.Bibliography)
+		m.Bibliographies = make(map[domain.BibliographyID]*domain.Bibliography)
 	}
 	m.Bibliographies[b.ID] = b
 	return nil
@@ -31,7 +29,7 @@ func (m *MockBibliographyRepository) FindAll() ([]*domain.Bibliography, error) {
 	return bibs, nil
 }
 
-func (m *MockBibliographyRepository) FindByID(id uuid.UUID) (*domain.Bibliography, error) {
+func (m *MockBibliographyRepository) FindByID(id domain.BibliographyID) (*domain.Bibliography, error) {
 	if m.Bibliographies == nil {
 		return nil, nil
 	}
@@ -42,24 +40,24 @@ func (m *MockBibliographyRepository) FindByBibIndex(_ string) (*domain.Bibliogra
 	return nil, nil
 }
 
-// MockBibClassificationRepository is a mock implementation of domain.BibClassificationRepository
-type MockBibClassificationRepository struct {
-	Classifications map[int]*domain.BibClassification
+// MockClassificationRepository is a mock implementation of domain.ClassificationRepository
+type MockClassificationRepository struct {
+	Classifications map[int]*domain.Classification
 }
 
-func (m *MockBibClassificationRepository) Save(c *domain.BibClassification) error {
+func (m *MockClassificationRepository) Save(c *domain.Classification) error {
 	if m.Classifications == nil {
-		m.Classifications = make(map[int]*domain.BibClassification)
+		m.Classifications = make(map[int]*domain.Classification)
 	}
 	m.Classifications[c.CodeNum] = c
 	return nil
 }
 
-func (m *MockBibClassificationRepository) FindAll() ([]*domain.BibClassification, error) {
+func (m *MockClassificationRepository) FindAll() ([]*domain.Classification, error) {
 	return nil, nil
 }
 
-func (m *MockBibClassificationRepository) FindByCodeNum(codeNum int) (*domain.BibClassification, error) {
+func (m *MockClassificationRepository) FindByCodeNum(codeNum int) (*domain.Classification, error) {
 	if c, ok := m.Classifications[codeNum]; ok {
 		return c, nil
 	}
@@ -69,8 +67,8 @@ func (m *MockBibClassificationRepository) FindByCodeNum(codeNum int) (*domain.Bi
 func TestAddBibliography(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			56: {CodeNum: 56, Name: "Technology"},
 		},
 	}
@@ -113,7 +111,7 @@ func TestAddBibliography(t *testing.T) {
 func TestAddClassification(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{}
+	classRepo := &MockClassificationRepository{}
 	svc := NewBibliographyService(bibRepo, classRepo)
 
 	// Test Case
@@ -148,8 +146,8 @@ func TestAddClassification(t *testing.T) {
 func TestAddClassification_Duplicate(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			99: {CodeNum: 99, Name: "Existing Class"},
 		},
 	}
@@ -170,8 +168,8 @@ func TestAddClassification_Duplicate(t *testing.T) {
 func TestAddBibliography_EmptyTitle(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			56: {CodeNum: 56, Name: "Technology"},
 		},
 	}
@@ -192,8 +190,8 @@ func TestAddBibliography_EmptyTitle(t *testing.T) {
 func TestAddBibliography_EmptyAuthor(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			56: {CodeNum: 56, Name: "Technology"},
 		},
 	}
@@ -214,8 +212,8 @@ func TestAddBibliography_EmptyAuthor(t *testing.T) {
 func TestAddBibliography_EmptyType(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			56: {CodeNum: 56, Name: "Technology"},
 		},
 	}
@@ -236,7 +234,7 @@ func TestAddBibliography_EmptyType(t *testing.T) {
 func TestAddClassification_EmptyName(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{}
+	classRepo := &MockClassificationRepository{}
 	svc := NewBibliographyService(bibRepo, classRepo)
 
 	// Test Case with empty name
@@ -254,7 +252,7 @@ func TestAddClassification_EmptyName(t *testing.T) {
 func TestAddClassification_WhitespaceName(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{}
+	classRepo := &MockClassificationRepository{}
 	svc := NewBibliographyService(bibRepo, classRepo)
 
 	// Test Case with whitespace-only name
@@ -298,8 +296,8 @@ func TestContainsJapanese(t *testing.T) {
 func TestAddBibliography_JapaneseWithEnglish(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			16: {CodeNum: 16, Name: "Philosophy"},
 		},
 	}
@@ -348,8 +346,8 @@ func TestAddBibliography_JapaneseWithEnglish(t *testing.T) {
 func TestAddBibliography_JapaneseWithoutEnglish_TitleError(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			16: {CodeNum: 16, Name: "Philosophy"},
 		},
 	}
@@ -381,8 +379,8 @@ func TestAddBibliography_JapaneseWithoutEnglish_TitleError(t *testing.T) {
 func TestAddBibliography_JapaneseWithoutEnglish_AuthorError(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			16: {CodeNum: 16, Name: "Philosophy"},
 		},
 	}
@@ -414,8 +412,8 @@ func TestAddBibliography_JapaneseWithoutEnglish_AuthorError(t *testing.T) {
 func TestAddBibliography_ManualBibIndex(t *testing.T) {
 	// Setup
 	bibRepo := &MockBibliographyRepository{}
-	classRepo := &MockBibClassificationRepository{
-		Classifications: map[int]*domain.BibClassification{
+	classRepo := &MockClassificationRepository{
+		Classifications: map[int]*domain.Classification{
 			56: {CodeNum: 56, Name: "Technology"},
 		},
 	}

--- a/internal/service/review_service.go
+++ b/internal/service/review_service.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type ReviewService struct {
@@ -21,7 +19,7 @@ func NewReviewService(reviewRepo domain.ReviewRepository, bibRepo domain.Bibliog
 	}
 }
 
-func (s *ReviewService) AddReview(bookID uuid.UUID, goals string, summary string) (*domain.Review, error) {
+func (s *ReviewService) AddReview(bookID domain.BibliographyID, goals string, summary string) (*domain.Review, error) {
 	// Validate inputs
 	// Note: 'goals' and 'summary' are text fields that may contain meaningful whitespace
 	// and line breaks, so we do NOT trim them before storage (unlike short identifier fields
@@ -43,7 +41,7 @@ func (s *ReviewService) AddReview(bookID uuid.UUID, goals string, summary string
 	}
 
 	review := &domain.Review{
-		ID:        uuid.New(),
+		ID:        domain.NewReviewID(),
 		BookID:    bookID,
 		Goals:     goals,
 		Summary:   summary,
@@ -63,7 +61,7 @@ func (s *ReviewService) AddReview(bookID uuid.UUID, goals string, summary string
 // If a field is nil, it will not be updated (preserves existing value).
 // For goals: if provided, must be non-empty/non-whitespace (cannot be set to empty string).
 // For summary: if provided, can be set to empty string (no validation).
-func (s *ReviewService) UpdateReview(id uuid.UUID, goals *string, summary *string) (*domain.Review, error) {
+func (s *ReviewService) UpdateReview(id domain.ReviewID, goals *string, summary *string) (*domain.Review, error) {
 	// Validate that at least one field is being updated
 	if goals == nil && summary == nil {
 		return nil, fmt.Errorf("at least one field (goals or summary) must be provided for update")


### PR DESCRIPTION
This pull request introduces domain-specific ID types for all major entities (Bibliography, Classification, Review) to improve type safety and prevent accidental misuse of IDs across the codebase. It refactors the domain models, repositories, and CSV persistence logic to use these new types instead of raw UUIDs, and updates documentation to reflect these changes.

**Domain Model and Type Safety Improvements**
* Added new types: `BibliographyID`, `ClassificationID`, and `ReviewID` as wrappers around `uuid.UUID`, with helper methods for string conversion, parsing, and generation. All entity structs now use these types for their `ID` fields. [[1]](diffhunk://#diff-c8eb6684af795a2bfffa8cda722878215a1c99f02287fafd3ea5e80380631917R4-R39) [[2]](diffhunk://#diff-bfaf9e2054a606df7ff37a9631a9008aa72be71c3fc30f6cd74d80a86b450798L3-R38) [[3]](diffhunk://#diff-ffdf806ca05c84831eab53ef4069b6cbc8229087afc98aa229468ff8245917afR4-R40)
* Updated repository interfaces and implementations to use domain-specific ID types for all relevant methods, replacing raw UUID usage. [[1]](diffhunk://#diff-ad927590fe28bd751ca90e5743052ffc7a99ceee7a0c2146ee5f38f30f4b8862L3-R23) [[2]](diffhunk://#diff-fcaef7e8a8cddeb87b202b0c392c19313909c42b839e7215cf121a16e0452606L106-R156) [[3]](diffhunk://#diff-17863f99d2b41c9b0bbc6eb9aee0cd3ea3864c8fe6562713d5fd17d43795c65bL44-R85) [[4]](diffhunk://#diff-14e8f70b40951f97391c2d6d9e3ed62b098562c4949d743edeee2271ac75bb39R5-R63)

**CSV Persistence Layer Refactoring**
* Refactored CSV repository implementations to convert between domain-specific types and CSV string representations, including new helper functions for each entity type. [[1]](diffhunk://#diff-fcaef7e8a8cddeb87b202b0c392c19313909c42b839e7215cf121a16e0452606R5-R62) [[2]](diffhunk://#diff-fcaef7e8a8cddeb87b202b0c392c19313909c42b839e7215cf121a16e0452606L61-R132) [[3]](diffhunk://#diff-fcaef7e8a8cddeb87b202b0c392c19313909c42b839e7215cf121a16e0452606R175-R185) [[4]](diffhunk://#diff-17863f99d2b41c9b0bbc6eb9aee0cd3ea3864c8fe6562713d5fd17d43795c65bR5-R58) [[5]](diffhunk://#diff-17863f99d2b41c9b0bbc6eb9aee0cd3ea3864c8fe6562713d5fd17d43795c65bL59-R112) [[6]](diffhunk://#diff-17863f99d2b41c9b0bbc6eb9aee0cd3ea3864c8fe6562713d5fd17d43795c65bL90-R134) [[7]](diffhunk://#diff-14e8f70b40951f97391c2d6d9e3ed62b098562c4949d743edeee2271ac75bb39R5-R63)

**Documentation Updates**
* Updated `docs/domain_model.md` to describe the new domain-specific ID types and their benefits, and revised entity definitions to use these types. [[1]](diffhunk://#diff-bb4c732459824a4c4488f01d558bf66301266b55b8ddf98827e624ebe193a601L6-R22) [[2]](diffhunk://#diff-bb4c732459824a4c4488f01d558bf66301266b55b8ddf98827e624ebe193a601L25-R48)

**Codebase Consistency**
* Renamed `BibClassification` to `Classification` throughout the codebase and updated constructor and repository names for clarity and consistency. [[1]](diffhunk://#diff-2ef419f6c61307b98832becda5af4160de6c8601677bc7c62ffa83a2e1b9228fL28-R28) [[2]](diffhunk://#diff-bfaf9e2054a606df7ff37a9631a9008aa72be71c3fc30f6cd74d80a86b450798L3-R38) [[3]](diffhunk://#diff-17863f99d2b41c9b0bbc6eb9aee0cd3ea3864c8fe6562713d5fd17d43795c65bR5-R58)

**Miscellaneous**
* Updated tests and main application code to use the new domain-specific ID types and parsing methods, removing direct dependencies on the `uuid` package in application logic. [[1]](diffhunk://#diff-9cdd8262defcc2de17d5275cfc12e5e321b1cb2b0f89475b40d561cf13bb860cL8-L9) [[2]](diffhunk://#diff-9cdd8262defcc2de17d5275cfc12e5e321b1cb2b0f89475b40d561cf13bb860cL31-R29) [[3]](diffhunk://#diff-77650a0abaad63c398dd6586eb28bbf3ab52ae7c1f7b3cae4f572b5fb51cdea5R4-L9) [[4]](diffhunk://#diff-77650a0abaad63c398dd6586eb28bbf3ab52ae7c1f7b3cae4f572b5fb51cdea5L124-R123)

Closes: #20